### PR TITLE
Arrows of SBML files without curveSegments are shown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,7 @@ api/static/*
 /libquaqua64.jnilib
 /obfuscation-log.xml
 /res/
+
+# Eclipse
+**/.metadata
+/bin/

--- a/src/main/java/edu/ucsd/sbrg/escher/EscherConverter.java
+++ b/src/main/java/edu/ucsd/sbrg/escher/EscherConverter.java
@@ -173,7 +173,8 @@ public class EscherConverter extends Launcher {
    */
   public static List<EscherMap> convert(SBMLDocument document, SBProperties properties) {
     SBML2Escher converter = new SBML2Escher();
-
+    converter.setNodeHeight(properties.getDoubleProperty(EscherOptions.PRIMARY_NODE_HEIGHT));
+    converter.setNodeWidth(properties.getDoubleProperty(EscherOptions.PRIMARY_NODE_WIDTH));
     return converter.convert(document);
   }
 
@@ -248,7 +249,7 @@ public class EscherConverter extends Launcher {
    * @param args Command line options, if any.
    */
   public static void main(String args[]) {
-    new EscherConverter(args);
+	new EscherConverter(args);
   }
 
 
@@ -842,7 +843,7 @@ public class EscherConverter extends Launcher {
    */
   @Override
   public boolean showsGUI() {
-    return !props.containsKey(GUIOptions.GUI) || props.getBooleanProperty(GUIOptions.GUI);
+	  	return !props.containsKey(GUIOptions.GUI) || props.getBooleanProperty(GUIOptions.GUI);
   }
 
 }

--- a/src/main/java/edu/ucsd/sbrg/escher/converter/SBML2Escher.java
+++ b/src/main/java/edu/ucsd/sbrg/escher/converter/SBML2Escher.java
@@ -39,6 +39,7 @@ import edu.ucsd.sbrg.escher.model.Node;
 import edu.ucsd.sbrg.escher.model.Point;
 import edu.ucsd.sbrg.escher.model.Segment;
 import edu.ucsd.sbrg.escher.model.TextLabel;
+import edu.ucsd.sbrg.escher.util.EscherOptions;
 
 /**
  * Converter from SBML Layout Extension to Escher.
@@ -72,13 +73,22 @@ public class SBML2Escher {
    * List of layouts exported from the SBML document.
    */
   protected List<Layout>    layouts;
-
+  
+  /**
+   * The height of primary nodes; in case bounding boxes have no dimensions
+   */
+  protected double primary_node_height;
+  
+  /**
+   * The width of primary nodes; in case bounding boxes have no dimensions
+   */
+  protected double primary_node_width;
 
   /**
    * Default constructor.
    */
   public SBML2Escher() {
-    escherMaps = new ArrayList<>();
+    escherMaps = new ArrayList<>(); 
   }
 
   /**
@@ -289,8 +299,14 @@ public class SBML2Escher {
         point.setX(pos.getX() + dim.getWidth() / 2d);
         point.setY(pos.getY() + dim.getHeight()/ 2d);
       } else {
-        point.setX(Double.NaN);
-        point.setY(Double.NaN);
+    	  if((bbox != null) && bbox.isSetPosition()){
+    		  org.sbml.jsbml.ext.layout.Point pos = bbox.getPosition();
+    		  point.setX(pos.getX() + primary_node_width/2);
+    	      point.setY(pos.getY() + primary_node_height/2);
+    	  }else{
+    		  point.setX(Double.NaN);
+    		  point.setY(Double.NaN);
+    	  }
       }
     }
     else {
@@ -462,8 +478,14 @@ public class SBML2Escher {
         point.setX(pos.getX() + dim.getWidth() / 2d);
         point.setY(pos.getY() + dim.getHeight()/ 2d);
       } else {
-        point.setX(Double.NaN);
-        point.setY(Double.NaN);
+    	  if((bbox != null) && bbox.isSetPosition()){
+    		  org.sbml.jsbml.ext.layout.Point pos = bbox.getPosition();
+    		  point.setX(pos.getX() + primary_node_width/2);
+    	      point.setY(pos.getY() + primary_node_height/2);
+    	  }else{
+    		  point.setX(Double.NaN);
+    		  point.setY(Double.NaN);
+    	  }
       }
     }
     else {
@@ -552,6 +574,16 @@ public class SBML2Escher {
       segments.add(segment);
       logger.info(format(messages.getString("CurveSegmentAdd"),
         segment.getId(), segment.getFromNodeId(), segment.getToNodeId()));
+    }else{
+    	// at the moment only straight lines are supported
+		Segment segment = new Segment();
+		segment.setId(sRG.getId() + ".S" + 0);
+   	    segment.setFromNodeId(rG.getId());
+		segment.setToNodeId(sRG.getSpeciesGlyph());
+	    segments.add(segment);
+	    logger.info(format(messages.getString("CurveSegmentAdd"),
+	        segment.getId(), segment.getFromNodeId(), segment.getToNodeId()));
+    	// TODO draw curves instead of straight lines
     }
 
     return segments;
@@ -607,6 +639,14 @@ public class SBML2Escher {
    */
   protected double midPoint(double d1, double d2) {
     return (d1 + d2)/2;
+  }
+  
+  public void setNodeHeight(double height){
+	  this.primary_node_height = height;
+  }
+  
+  public void setNodeWidth(double width){
+	  this.primary_node_width = width;
   }
 
 }


### PR DESCRIPTION
Arrows are now inferred from `SpeciesReferenceGlyphs`.
If no dimensions are given, start and end points of arrows are calculated using the default node width/height.
`.gitignore` was changed so that Eclipse can be used.