### PR TITLE
If layout id and model id are the same, layout id is changed

### DIFF
--- a/src/main/java/edu/ucsd/sbrg/escher/converter/Escher2Standard.java
+++ b/src/main/java/edu/ucsd/sbrg/escher/converter/Escher2Standard.java
@@ -232,7 +232,15 @@ public abstract class Escher2Standard<T> {
       Segment segment = entry.getValue();
       Node fromNode = escherMap.getNode(segment.getFromNodeId());
       Node toNode = escherMap.getNode(segment.getToNodeId());
+      
       Node srGlyph = null;
+      if(toNode == null){
+    	  logger.severe(format(bundle.getString("Escher2Standard.missing_node"),
+    			  segment.getToNodeId(), reaction.getBiggId()));
+      }else if (fromNode == null){
+    	  logger.severe(format(bundle.getString("Escher2Standard.missing_node"),
+    			  segment.getFromNodeId(), reaction.getBiggId()));
+      }else{
       if (fromNode.isMetabolite()) {
         srGlyph = escherMap.getNode(fromNode.getId());
         Metabolite metabolite = reaction.getMetabolite(fromNode.getBiggId());
@@ -258,6 +266,7 @@ public abstract class Escher2Standard<T> {
         // Here we have no information about directionality and just keep it as given.
         fromNode.addConnectedSegment(reaction.getId(), segment);
         toNode.addConnectedSegment(reaction.getId(), segment);
+      }
       }
       if (srGlyph != null) {
         List<String>

--- a/src/main/resources/edu/ucsd/sbrg/escher/Messages.xml
+++ b/src/main/resources/edu/ucsd/sbrg/escher/Messages.xml
@@ -107,6 +107,7 @@
   <entry key="Escher2SBML.glyphIdNull">SpeciesGlyph for id=\"{0}\" is null.</entry>
   <entry key="Escher2SBML.textLabelIdNotUnique">Found text label with id=''{0}'' that is identical to the id of a {1}</entry>
   <entry key="Escher2SBML.reactionCompartmentUnknown">Could not identify compartment of reaction {0}</entry>
+  <entry key="Escher2SBML.layoutIDnotunique">Layout identifier {0} changed to {1} as it is the same as model's id {2}.</entry>
   
   <entry key="Escher2Standard.reversed_segment">Reversed direction of segment {0}: {1} -> {2}.</entry>
   <entry key="Escher2Standard.node_lacking_metabolite">Node ''{0}'' in reaction ''{1}'' lacks a corresponding metabolite.</entry>

--- a/src/main/resources/edu/ucsd/sbrg/escher/Messages.xml
+++ b/src/main/resources/edu/ucsd/sbrg/escher/Messages.xml
@@ -114,6 +114,7 @@
   <entry key="Escher2Standard.inconsistent_data_structure">Inconsistent data structure! Glyph ''{0}'' does not contain pointer to segment ''{1}''.</entry>
   <entry key="Escher2Standard.multiple_arcs">Data structure indicates that glyph ''{0}'' participates in reaction ''{1}'' with multiple arcs: {1}.</entry>
   <entry key="Escher2Standard.metabolite_lacking_node">Metabolite ''{0}'' in reaction ''{1}'' lacks a corresponding node.</entry>
+  <entry key="Escher2Standard.missing_node">Node ''{0}'' cannot be found in reaction ''{1}''.</entry>
   
   <entry key="EscherCompartment.invalidId">Invalid compartment identifier ''{0}''.</entry>
   


### PR DESCRIPTION
After converting a .json file to .sbml and back, it happens that the model's id and the given layout id are the same which leads to an `IllegalArgumentException` (issue #36).
Therefore, if the same names are detected, the layout id is changed and a log message is written to the output.
While converting reactions, sometimes nodes cannot be found. This might be due to mistakes in input files. These nodes are skipped and a message is output to the logger. This should solve issue #46.