### PR TITLE
When compartment boundaries should be inferred and no x and y coordin…

### DIFF
--- a/src/main/java/edu/ucsd/sbrg/escher/converter/Escher2SBML.java
+++ b/src/main/java/edu/ucsd/sbrg/escher/converter/Escher2SBML.java
@@ -102,6 +102,8 @@ public class Escher2SBML extends Escher2Standard<SBMLDocument> {
     Canvas canvas = map.getCanvas();
     double xOffset = canvas.isSetX() ? canvas.getX().doubleValue() : 0d;
     double yOffset = canvas.isSetY() ? canvas.getY().doubleValue() : 0d;
+    double canvasWidth = canvas.getWidth();
+    double canvasHeight = canvas.getWidth();
     Map<String, String> node2glyph = new HashMap<String, String>();
     Map<String, Node> multimarkers = new HashMap<String, Node>();
     Layout layout = initLayout(map, xOffset, yOffset);
@@ -119,7 +121,7 @@ public class Escher2SBML extends Escher2Standard<SBMLDocument> {
         String id = entry.getKey();
         if (!(id.equalsIgnoreCase("n") || id.equalsIgnoreCase(getDefaultCompartmentId())
             || id.equalsIgnoreCase("e"))) {
-          createCompartmentGlyph(entry.getValue(), layout, xOffset, yOffset);
+          createCompartmentGlyph(entry.getValue(), layout, xOffset, yOffset, canvasWidth, canvasHeight);
         }
       }
     }
@@ -137,11 +139,44 @@ public class Escher2SBML extends Escher2Standard<SBMLDocument> {
    * @param yOffset y-offset.
    */
   private void createCompartmentGlyph(EscherCompartment ec, Layout layout,
-    double xOffset, double yOffset) {
+    double xOffset, double yOffset, double canvasWidth, double canvasHeight) {
+	//TODO
+	//for now, if no x and y coordinates are available, the compartment is set around all nodes
     CompartmentGlyph cg = layout.createCompartmentGlyph(ec.getId() + "_glyph");
-    double x = ec.getX() - xOffset - getPrimaryNodeWidth();
-    double y = ec.getY() - yOffset - getPrimaryNodeHeight();
-    cg.createBoundingBox(ec.getWidth(), ec.getHeight(), getNodeDepth(), x, y, getZ());
+    double x;
+    double y; 
+    double width; 
+    double height; 
+    if(ec.getX()==null){
+    	x = xOffset;
+    	logger.severe(format(bundle.getString("Escher2SBML.inferredCompartment"),
+      	      ec.getName(), "x-offset", "x-offset of the canvas: "+ xOffset));
+    }else{
+    	x= ec.getX() - xOffset - getPrimaryNodeWidth();
+    	
+    }
+    if(ec.getY()==null){
+    	y = yOffset;
+    	logger.severe(format(bundle.getString("Escher2SBML.inferredCompartment"),
+      	      ec.getName(), "y-offset", "y-offset of the canvas: "+yOffset));
+    }else{
+    	y= ec.getY() - yOffset - getPrimaryNodeWidth();
+    }
+    if(ec.getWidth()==null ){
+    	width = canvasWidth;
+    	logger.severe(format(bundle.getString("Escher2SBML.inferredCompartment"),
+      	      ec.getName(), "the width", "the width of the canvas: "+canvasWidth));
+    }else{
+    	width = ec.getWidth();
+    }
+    if(ec.getHeight()==null ){
+    	height = canvasHeight;
+    	logger.severe(format(bundle.getString("Escher2SBML.inferredCompartment"),
+        	      ec.getName(), "the height", "the height of the canvas: "+canvasHeight));
+    }else{
+    	height = ec.getHeight();
+    }
+    cg.createBoundingBox(width, height, getNodeDepth(), x, y, getZ());
     cg.setCompartment(SBMLtools.toSId(ec.getId()));
     NamedSBase compartment = cg.getCompartmentInstance();
     if ((compartment != null) && compartment.isSetName()) {
@@ -150,6 +185,7 @@ public class Escher2SBML extends Escher2Standard<SBMLDocument> {
       text.createBoundingBox(compartment.getName().length() * 5d,
         getNodeLabelHeight(), getNodeDepth(), x, y, getZ());
     }
+    
   }
 
 

--- a/src/main/resources/edu/ucsd/sbrg/escher/Messages.xml
+++ b/src/main/resources/edu/ucsd/sbrg/escher/Messages.xml
@@ -108,6 +108,8 @@
   <entry key="Escher2SBML.textLabelIdNotUnique">Found text label with id=''{0}'' that is identical to the id of a {1}</entry>
   <entry key="Escher2SBML.reactionCompartmentUnknown">Could not identify compartment of reaction {0}</entry>
   <entry key="Escher2SBML.layoutIDnotunique">Layout identifier {0} changed to {1} as it is the same as model's id {2}.</entry>
+  <entry key="Escher2SBML.metaboliteId_missing">{0} is not a valid id for a metabolite in reaction {1}.</entry>
+  <entry key="Escher2SBML.inferredCompartment">In Compartment ''{0}'' {1} was not available and was therefore set to {2}.</entry>
   
   <entry key="Escher2Standard.reversed_segment">Reversed direction of segment {0}: {1} -> {2}.</entry>
   <entry key="Escher2Standard.node_lacking_metabolite">Node ''{0}'' in reaction ''{1}'' lacks a corresponding metabolite.</entry>


### PR DESCRIPTION
…ates are available, they are drawn around the canvas
This is not perfect; ideally they should be inferred from the nodes within the compartment. However, this seems to be impossible at the moment because `EscherCompartment` has no attribute containing its nodes. The part is marked with a TODO, but that is all I can do for now.
This should at least on the surface fix issue #53 